### PR TITLE
feature(elm): Submit on enter

### DIFF
--- a/aion/web/channels/channel_monitor.ex
+++ b/aion/web/channels/channel_monitor.ex
@@ -90,6 +90,7 @@ defmodule Aion.ChannelMonitor do
                |> Enum.random
     question_id = Map.get(question, :id)
     answers = Repo.all(from a in Answer, where: a.question_id == ^question_id)
+    IO.inspect answers, label: "Answers"
     %{question: question, answers: answers}
   end
   defp increment_score(user_record) do

--- a/aion/web/elm/src/Msgs.elm
+++ b/aion/web/elm/src/Msgs.elm
@@ -20,3 +20,4 @@ type Msg
     | ReceiveQuestion Encode.Value
     | FocusResult (Result Error ())
     | KeyDown Int
+    | NoOperation

--- a/aion/web/elm/src/Msgs.elm
+++ b/aion/web/elm/src/Msgs.elm
@@ -19,3 +19,4 @@ type Msg
     | SubmitAnswer RoomId
     | ReceiveQuestion Encode.Value
     | FocusResult (Result Error ())
+    | KeyDown Int

--- a/aion/web/elm/src/Room/View.elm
+++ b/aion/web/elm/src/Room/View.elm
@@ -1,16 +1,17 @@
 module Room.View exposing (..)
 
 import General.Models exposing (Model)
-import Html exposing (Html, a, button, div, form, input, li, text, ul)
+import Html exposing (Attribute, Html, a, button, div, form, input, li, text, ul)
 import Html.Attributes exposing (href, id, type_, value)
-import Html.Events exposing (onClick, onInput)
+import Html.Events exposing (keyCode, on, onClick, onInput)
 import Room.Utils exposing (getRoomList, getRoomNameById)
-import Msgs exposing (Msg(SetAnswer, SubmitAnswer))
+import Msgs exposing (Msg(KeyDown, SetAnswer, SubmitAnswer))
 import Html exposing (Html, a, div, img, li, p, text, ul)
 import Html.Attributes exposing (href, src)
 import Msgs exposing (Msg)
 import RemoteData exposing (WebData)
 import Room.Models exposing (RoomId, RoomsData, UserInRoomRecord, answerInputFieldId)
+import Json.Decode exposing (map)
 
 
 roomListView : Model -> Html Msg
@@ -59,9 +60,14 @@ displayQuestionImage model =
 displayAnswerInput : Model -> RoomId -> Html Msg
 displayAnswerInput model roomId =
     form []
-        [ input [ id answerInputFieldId, onInput SetAnswer ] []
+        [ input [ id answerInputFieldId, onInput SetAnswer, onKeyDown KeyDown ] []
         , input [ type_ "button", value "submit", onClick (SubmitAnswer roomId) ] []
         ]
+
+
+onKeyDown : (Int -> msg) -> Attribute msg
+onKeyDown tagger =
+    on "keydown" (map tagger keyCode)
 
 
 listRooms : WebData RoomsData -> Html Msg

--- a/aion/web/elm/src/Room/View.elm
+++ b/aion/web/elm/src/Room/View.elm
@@ -5,7 +5,7 @@ import Html exposing (Attribute, Html, a, button, div, form, input, li, text, ul
 import Html.Attributes exposing (href, id, type_, value)
 import Html.Events exposing (keyCode, on, onClick, onInput, onWithOptions)
 import Room.Utils exposing (getRoomList, getRoomNameById)
-import Msgs exposing (Msg(KeyDown, SetAnswer, SubmitAnswer))
+import Msgs exposing (Msg(KeyDown, NoOperation, SetAnswer, SubmitAnswer))
 import Html exposing (Html, a, div, img, li, p, text, ul)
 import Html.Attributes exposing (href, src)
 import Msgs exposing (Msg)
@@ -59,7 +59,7 @@ displayQuestionImage model =
 
 displayAnswerInput : RoomId -> Html Msg
 displayAnswerInput roomId =
-    form [ onWithOptions "submit" { preventDefault = True, stopPropagation = False } (Json.Decode.succeed (KeyDown 1)) ]
+    form [ onWithOptions "submit" { preventDefault = True, stopPropagation = False } (Json.Decode.succeed (NoOperation)) ]
         [ input [ id answerInputFieldId, onInput SetAnswer, onKeyDown KeyDown ] []
         , input [ type_ "button", value "submit", onClick (SubmitAnswer roomId) ] []
         ]

--- a/aion/web/elm/src/Room/View.elm
+++ b/aion/web/elm/src/Room/View.elm
@@ -3,7 +3,7 @@ module Room.View exposing (..)
 import General.Models exposing (Model)
 import Html exposing (Attribute, Html, a, button, div, form, input, li, text, ul)
 import Html.Attributes exposing (href, id, type_, value)
-import Html.Events exposing (keyCode, on, onClick, onInput)
+import Html.Events exposing (keyCode, on, onClick, onInput, onWithOptions)
 import Room.Utils exposing (getRoomList, getRoomNameById)
 import Msgs exposing (Msg(KeyDown, SetAnswer, SubmitAnswer))
 import Html exposing (Html, a, div, img, li, p, text, ul)
@@ -59,7 +59,7 @@ displayQuestionImage model =
 
 displayAnswerInput : RoomId -> Html Msg
 displayAnswerInput roomId =
-    form []
+    form [ onWithOptions "submit" { preventDefault = True, stopPropagation = False } (Json.Decode.succeed (KeyDown 1)) ]
         [ input [ id answerInputFieldId, onInput SetAnswer, onKeyDown KeyDown ] []
         , input [ type_ "button", value "submit", onClick (SubmitAnswer roomId) ] []
         ]

--- a/aion/web/elm/src/Room/View.elm
+++ b/aion/web/elm/src/Room/View.elm
@@ -33,7 +33,7 @@ roomView model roomId =
             , displayScores model
             , p [] [ text model.questionInChannel.content ]
             , displayQuestionImage model
-            , displayAnswerInput model roomId
+            , displayAnswerInput roomId
             ]
 
 
@@ -57,8 +57,8 @@ displayQuestionImage model =
             img [ src ("http://localhost:4000/images/" ++ imageName) ] []
 
 
-displayAnswerInput : Model -> RoomId -> Html Msg
-displayAnswerInput model roomId =
+displayAnswerInput : RoomId -> Html Msg
+displayAnswerInput roomId =
     form []
         [ input [ id answerInputFieldId, onInput SetAnswer, onKeyDown KeyDown ] []
         , input [ type_ "button", value "submit", onClick (SubmitAnswer roomId) ] []

--- a/aion/web/elm/src/Update.elm
+++ b/aion/web/elm/src/Update.elm
@@ -91,3 +91,13 @@ update msg model =
 
         FocusResult result ->
             model ! []
+
+        KeyDown key ->
+            let
+                enter =
+                    13
+            in
+                if key == enter then
+                    update (SubmitAnswer model.roomId) model
+                else
+                    model ! []

--- a/aion/web/elm/src/Update.elm
+++ b/aion/web/elm/src/Update.elm
@@ -101,3 +101,6 @@ update msg model =
                     update (SubmitAnswer model.roomId) model
                 else
                     model ! []
+
+        NoOperation ->
+            model ! []


### PR DESCRIPTION
**Summary**
This PR adds automatic submission of answer once enter key is hit with the textbox active. The problem is that the first two hits cause the page to refresh which is far from what we want to achieve. I am not yet sure how to solve this issue, therefore I ask for help.

**Related issues**
Closes: #23 

**Test plan**
To test, navigate to a room, for example to [http://localhost:4000/#rooms/15](http://localhost:4000/#rooms/15) 
![image](https://user-images.githubusercontent.com/15965147/26886621-2708ad20-4ba6-11e7-9959-0bf69d3b5a47.png)
Now start writing in the textbox and hit enter - Elm should navigate to [http://localhost:4000/?#rooms/15](http://localhost:4000/?#rooms/15) (notice the question mark) and clear the answer
![image](https://user-images.githubusercontent.com/15965147/26886691-545ec19c-4ba6-11e7-98d5-d29419daf22b.png)
Once you start writing again and hit enter the picture will load once again and the page will work as it should 
![image](https://user-images.githubusercontent.com/15965147/26886794-a2bf8e48-4ba6-11e7-8d54-8b9745afbe1a.png)
I'm not sure what is the reason for such a behaviour.


