### PR TITLE
feat(phoenix): Add Room model

### DIFF
--- a/aion/priv/repo/migrations/20170708113616_create_room.exs
+++ b/aion/priv/repo/migrations/20170708113616_create_room.exs
@@ -5,12 +5,10 @@ defmodule Aion.Repo.Migrations.CreateRoom do
     create table(:rooms) do
       add :name, :string
       add :description, :text
-      add :owner, references(:users, on_delete: :nothing)
 
       timestamps()
     end
     create unique_index(:rooms, [:name])
-    create index(:rooms, [:owner])
 
   end
 end

--- a/aion/priv/repo/migrations/20170708113616_create_room.exs
+++ b/aion/priv/repo/migrations/20170708113616_create_room.exs
@@ -1,0 +1,16 @@
+defmodule Aion.Repo.Migrations.CreateRoom do
+  use Ecto.Migration
+
+  def change do
+    create table(:rooms) do
+      add :name, :string
+      add :description, :text
+      add :owner, references(:users, on_delete: :nothing)
+
+      timestamps()
+    end
+    create unique_index(:rooms, [:name])
+    create index(:rooms, [:owner])
+
+  end
+end

--- a/aion/priv/repo/migrations/20170708113722_create_room_subject.exs
+++ b/aion/priv/repo/migrations/20170708113722_create_room_subject.exs
@@ -1,0 +1,15 @@
+defmodule Aion.Repo.Migrations.CreateRoomSubject do
+  use Ecto.Migration
+
+  def change do
+    create table(:room_subjects) do
+      add :room_id, references(:rooms, on_delete: :nothing)
+      add :subject_id, references(:subjects, on_delete: :nothing)
+
+      timestamps()
+    end
+    create index(:room_subjects, [:room_id])
+    create index(:room_subjects, [:subject_id])
+
+  end
+end

--- a/aion/priv/repo/migrations/20170708113722_create_room_subject.exs
+++ b/aion/priv/repo/migrations/20170708113722_create_room_subject.exs
@@ -3,8 +3,8 @@ defmodule Aion.Repo.Migrations.CreateRoomSubject do
 
   def change do
     create table(:room_subjects) do
-      add :room_id, references(:rooms, on_delete: :nothing)
-      add :subject_id, references(:subjects, on_delete: :nothing)
+      add :room_id, references(:rooms, on_delete: :delete_all)
+      add :subject_id, references(:subjects, on_delete: :delete_all)
 
       timestamps()
     end

--- a/aion/test/controllers/answer_controller_test.exs
+++ b/aion/test/controllers/answer_controller_test.exs
@@ -5,9 +5,9 @@ defmodule Aion.AnswerControllerTest do
   @valid_attrs %{content: "some content"}
   @invalid_attrs %{}
 
-  setup %{conn: _} do
+  setup do
     user = %{ email: "test@example.com", name: "something" }
-    conn = Plug.Test. init_test_session(build_conn(), %{current_user: user})
+    conn = Plug.Test.init_test_session(build_conn(), %{current_user: user})
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 

--- a/aion/test/controllers/question_controller_test.exs
+++ b/aion/test/controllers/question_controller_test.exs
@@ -2,7 +2,6 @@ defmodule Aion.QuestionControllerTest do
   use Aion.ConnCase
 
   alias Aion.Question
-  alias Aion.Subject
 
   @valid_attrs %{content: "some content", image_name: "some content"}
   @invalid_attrs %{}

--- a/aion/test/controllers/room_controller_test.exs
+++ b/aion/test/controllers/room_controller_test.exs
@@ -1,0 +1,62 @@
+defmodule Aion.RoomControllerTest do
+  use Aion.ConnCase
+
+  alias Aion.Room
+  @valid_attrs %{description: "some content", name: "some content"}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, room_path(conn, :index)
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    room = Repo.insert! %Room{}
+    conn = get conn, room_path(conn, :show, room)
+    assert json_response(conn, 200)["data"] == %{"id" => room.id,
+      "name" => room.name,
+      "description" => room.description,
+      "owner" => room.owner}
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, room_path(conn, :show, -1)
+    end
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    conn = post conn, room_path(conn, :create), room: @valid_attrs
+    assert json_response(conn, 201)["data"]["id"]
+    assert Repo.get_by(Room, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, room_path(conn, :create), room: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "updates and renders chosen resource when data is valid", %{conn: conn} do
+    room = Repo.insert! %Room{}
+    conn = put conn, room_path(conn, :update, room), room: @valid_attrs
+    assert json_response(conn, 200)["data"]["id"]
+    assert Repo.get_by(Room, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    room = Repo.insert! %Room{}
+    conn = put conn, room_path(conn, :update, room), room: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    room = Repo.insert! %Room{}
+    conn = delete conn, room_path(conn, :delete, room)
+    assert response(conn, 204)
+    refute Repo.get(Room, room.id)
+  end
+end

--- a/aion/test/controllers/room_controller_test.exs
+++ b/aion/test/controllers/room_controller_test.exs
@@ -5,7 +5,9 @@ defmodule Aion.RoomControllerTest do
   @valid_attrs %{description: "some content", name: "some content"}
   @invalid_attrs %{}
 
-  setup %{conn: conn} do
+  setup do
+    user = %{ email: "test@example.com", name: "something" }
+    conn = Plug.Test. init_test_session(build_conn(), %{current_user: user})
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 

--- a/aion/test/controllers/room_controller_test.exs
+++ b/aion/test/controllers/room_controller_test.exs
@@ -21,8 +21,7 @@ defmodule Aion.RoomControllerTest do
     conn = get conn, room_path(conn, :show, room)
     assert json_response(conn, 200)["data"] == %{"id" => room.id,
       "name" => room.name,
-      "description" => room.description,
-      "owner" => room.owner}
+      "description" => room.description}
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/aion/test/controllers/room_subject_controller_test.exs
+++ b/aion/test/controllers/room_subject_controller_test.exs
@@ -5,7 +5,9 @@ defmodule Aion.RoomSubjectControllerTest do
   @valid_attrs %{}
   @invalid_attrs %{}
 
-  setup %{conn: conn} do
+  setup do
+    user = %{ email: "test@example.com", name: "something" }
+    conn = Plug.Test. init_test_session(build_conn(), %{current_user: user})
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 

--- a/aion/test/controllers/room_subject_controller_test.exs
+++ b/aion/test/controllers/room_subject_controller_test.exs
@@ -3,7 +3,6 @@ defmodule Aion.RoomSubjectControllerTest do
 
   alias Aion.RoomSubject
   @valid_attrs %{}
-  @invalid_attrs %{}
 
   setup do
     user = %{ email: "test@example.com", name: "something" }
@@ -36,22 +35,11 @@ defmodule Aion.RoomSubjectControllerTest do
     assert Repo.get_by(RoomSubject, @valid_attrs)
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, room_subject_path(conn, :create), room_subject: @invalid_attrs
-    assert json_response(conn, 422)["errors"] != %{}
-  end
-
   test "updates and renders chosen resource when data is valid", %{conn: conn} do
     room_subject = Repo.insert! %RoomSubject{}
     conn = put conn, room_subject_path(conn, :update, room_subject), room_subject: @valid_attrs
     assert json_response(conn, 200)["data"]["id"]
     assert Repo.get_by(RoomSubject, @valid_attrs)
-  end
-
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    room_subject = Repo.insert! %RoomSubject{}
-    conn = put conn, room_subject_path(conn, :update, room_subject), room_subject: @invalid_attrs
-    assert json_response(conn, 422)["errors"] != %{}
   end
 
   test "deletes chosen resource", %{conn: conn} do

--- a/aion/test/controllers/room_subject_controller_test.exs
+++ b/aion/test/controllers/room_subject_controller_test.exs
@@ -1,0 +1,61 @@
+defmodule Aion.RoomSubjectControllerTest do
+  use Aion.ConnCase
+
+  alias Aion.RoomSubject
+  @valid_attrs %{}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, room_subject_path(conn, :index)
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    room_subject = Repo.insert! %RoomSubject{}
+    conn = get conn, room_subject_path(conn, :show, room_subject)
+    assert json_response(conn, 200)["data"] == %{"id" => room_subject.id,
+      "room_id" => room_subject.room_id,
+      "subject_id" => room_subject.subject_id}
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, room_subject_path(conn, :show, -1)
+    end
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    conn = post conn, room_subject_path(conn, :create), room_subject: @valid_attrs
+    assert json_response(conn, 201)["data"]["id"]
+    assert Repo.get_by(RoomSubject, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, room_subject_path(conn, :create), room_subject: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "updates and renders chosen resource when data is valid", %{conn: conn} do
+    room_subject = Repo.insert! %RoomSubject{}
+    conn = put conn, room_subject_path(conn, :update, room_subject), room_subject: @valid_attrs
+    assert json_response(conn, 200)["data"]["id"]
+    assert Repo.get_by(RoomSubject, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    room_subject = Repo.insert! %RoomSubject{}
+    conn = put conn, room_subject_path(conn, :update, room_subject), room_subject: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    room_subject = Repo.insert! %RoomSubject{}
+    conn = delete conn, room_subject_path(conn, :delete, room_subject)
+    assert response(conn, 204)
+    refute Repo.get(RoomSubject, room_subject.id)
+  end
+end

--- a/aion/test/models/room_subject_test.exs
+++ b/aion/test/models/room_subject_test.exs
@@ -1,0 +1,18 @@
+defmodule Aion.RoomSubjectTest do
+  use Aion.ModelCase
+
+  alias Aion.RoomSubject
+
+  @valid_attrs %{}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = RoomSubject.changeset(%RoomSubject{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = RoomSubject.changeset(%RoomSubject{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/aion/test/models/room_subject_test.exs
+++ b/aion/test/models/room_subject_test.exs
@@ -4,15 +4,9 @@ defmodule Aion.RoomSubjectTest do
   alias Aion.RoomSubject
 
   @valid_attrs %{}
-  @invalid_attrs %{}
 
   test "changeset with valid attributes" do
     changeset = RoomSubject.changeset(%RoomSubject{}, @valid_attrs)
     assert changeset.valid?
-  end
-
-  test "changeset with invalid attributes" do
-    changeset = RoomSubject.changeset(%RoomSubject{}, @invalid_attrs)
-    refute changeset.valid?
   end
 end

--- a/aion/test/models/room_test.exs
+++ b/aion/test/models/room_test.exs
@@ -1,0 +1,18 @@
+defmodule Aion.RoomTest do
+  use Aion.ModelCase
+
+  alias Aion.Room
+
+  @valid_attrs %{description: "some content", name: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Room.changeset(%Room{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Room.changeset(%Room{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/aion/web/controllers/room_controller.ex
+++ b/aion/web/controllers/room_controller.ex
@@ -1,0 +1,55 @@
+defmodule Aion.RoomController do
+  use Aion.Web, :controller
+
+  alias Aion.Room
+
+  def index(conn, _params) do
+    rooms = Repo.all(Room)
+    render(conn, "index.json", rooms: rooms)
+  end
+
+  def create(conn, %{"room" => room_params}) do
+    changeset = Room.changeset(%Room{}, room_params)
+
+    case Repo.insert(changeset) do
+      {:ok, room} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", room_path(conn, :show, room))
+        |> render("show.json", room: room)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Aion.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    room = Repo.get!(Room, id)
+    render(conn, "show.json", room: room)
+  end
+
+  def update(conn, %{"id" => id, "room" => room_params}) do
+    room = Repo.get!(Room, id)
+    changeset = Room.changeset(room, room_params)
+
+    case Repo.update(changeset) do
+      {:ok, room} ->
+        render(conn, "show.json", room: room)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Aion.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    room = Repo.get!(Room, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(room)
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/aion/web/controllers/room_subject_controller.ex
+++ b/aion/web/controllers/room_subject_controller.ex
@@ -1,0 +1,55 @@
+defmodule Aion.RoomSubjectController do
+  use Aion.Web, :controller
+
+  alias Aion.RoomSubject
+
+  def index(conn, _params) do
+    room_subjects = Repo.all(RoomSubject)
+    render(conn, "index.json", room_subjects: room_subjects)
+  end
+
+  def create(conn, %{"room_subject" => room_subject_params}) do
+    changeset = RoomSubject.changeset(%RoomSubject{}, room_subject_params)
+
+    case Repo.insert(changeset) do
+      {:ok, room_subject} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", room_subject_path(conn, :show, room_subject))
+        |> render("show.json", room_subject: room_subject)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Aion.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    room_subject = Repo.get!(RoomSubject, id)
+    render(conn, "show.json", room_subject: room_subject)
+  end
+
+  def update(conn, %{"id" => id, "room_subject" => room_subject_params}) do
+    room_subject = Repo.get!(RoomSubject, id)
+    changeset = RoomSubject.changeset(room_subject, room_subject_params)
+
+    case Repo.update(changeset) do
+      {:ok, room_subject} ->
+        render(conn, "show.json", room_subject: room_subject)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Aion.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    room_subject = Repo.get!(RoomSubject, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(room_subject)
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/aion/web/models/room.ex
+++ b/aion/web/models/room.ex
@@ -1,14 +1,15 @@
 defmodule Aion.Room do
+  @moduledoc """
+    Represents a game room with different categories of questions
+  """
   use Aion.Web, :model
-  alias Aion.{Subject, RoomSubject, User}
+  alias Aion.{Subject, RoomSubject}
 
   schema "rooms" do
     field :name, :string
     field :description, :string
     many_to_many :subjects, Subject,
-      join_through: RoomSubject,
-      on_delete: :delete_all
-    belongs_to :owner, Aion.User
+      join_through: RoomSubject
 
     timestamps()
   end

--- a/aion/web/models/room.ex
+++ b/aion/web/models/room.ex
@@ -1,0 +1,21 @@
+defmodule Aion.Room do
+  use Aion.Web, :model
+
+  schema "rooms" do
+    field :name, :string
+    field :description, :string
+    belongs_to :owner, Aion.Owner
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :description])
+    |> validate_required([:name, :description])
+    |> unique_constraint(:name)
+  end
+end

--- a/aion/web/models/room.ex
+++ b/aion/web/models/room.ex
@@ -1,12 +1,12 @@
 defmodule Aion.Room do
   use Aion.Web, :model
-  alias Aion.{Subject, RoomSubject}
+  alias Aion.{Subject, RoomSubject, User}
 
   schema "rooms" do
     field :name, :string
     field :description, :string
     many_to_many :subjects, Subject, join_through: RoomSubject
-    belongs_to :owner, Aion.Owner
+    belongs_to :owner, Aion.User
 
     timestamps()
   end

--- a/aion/web/models/room.ex
+++ b/aion/web/models/room.ex
@@ -9,9 +9,10 @@ defmodule Aion.Room do
     field :name, :string
     field :description, :string
     many_to_many :subjects, Subject,
-      join_through: RoomSubject
+      join_through: RoomSubject,
+      on_delete: :delete_all
 
-    timestamps()
+      timestamps()
   end
 
   @doc """

--- a/aion/web/models/room.ex
+++ b/aion/web/models/room.ex
@@ -5,7 +5,9 @@ defmodule Aion.Room do
   schema "rooms" do
     field :name, :string
     field :description, :string
-    many_to_many :subjects, Subject, join_through: RoomSubject
+    many_to_many :subjects, Subject,
+      join_through: RoomSubject,
+      on_delete: :delete_all
     belongs_to :owner, Aion.User
 
     timestamps()

--- a/aion/web/models/room.ex
+++ b/aion/web/models/room.ex
@@ -1,9 +1,11 @@
 defmodule Aion.Room do
   use Aion.Web, :model
+  alias Aion.{Subject, RoomSubject}
 
   schema "rooms" do
     field :name, :string
     field :description, :string
+    many_to_many :subjects, Subject, join_through: RoomSubject
     belongs_to :owner, Aion.Owner
 
     timestamps()

--- a/aion/web/models/room_subject.ex
+++ b/aion/web/models/room_subject.ex
@@ -1,4 +1,7 @@
 defmodule Aion.RoomSubject do
+  @moduledoc """
+    Join table between Room and Subject
+  """
   use Aion.Web, :model
 
   schema "room_subjects" do

--- a/aion/web/models/room_subject.ex
+++ b/aion/web/models/room_subject.ex
@@ -1,0 +1,19 @@
+defmodule Aion.RoomSubject do
+  use Aion.Web, :model
+
+  schema "room_subjects" do
+    belongs_to :room, Aion.Room
+    belongs_to :subject, Aion.Subject
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [])
+    |> validate_required([])
+  end
+end

--- a/aion/web/models/subject.ex
+++ b/aion/web/models/subject.ex
@@ -7,7 +7,8 @@ defmodule Aion.Subject do
   schema "subjects" do
     field :name, :string
     many_to_many :rooms, Room,
-      join_through: RoomSubject
+      join_through: RoomSubject,
+      on_delete: :delete_all
 
     timestamps()
   end

--- a/aion/web/models/subject.ex
+++ b/aion/web/models/subject.ex
@@ -7,8 +7,8 @@ defmodule Aion.Subject do
   schema "subjects" do
     field :name, :string
     many_to_many :rooms, Room,
-      join_through: RoomSubject,
-      on_delete: :delete_all
+      join_through: RoomSubject
+
     timestamps()
   end
 

--- a/aion/web/models/subject.ex
+++ b/aion/web/models/subject.ex
@@ -6,7 +6,9 @@ defmodule Aion.Subject do
   alias Aion.{Room, RoomSubject}
   schema "subjects" do
     field :name, :string
-    many_to_many :rooms, Room, join_through: RoomSubject
+    many_to_many :rooms, Room,
+      join_through: RoomSubject,
+      on_delete: :delete_all
     timestamps()
   end
 

--- a/aion/web/models/subject.ex
+++ b/aion/web/models/subject.ex
@@ -3,10 +3,10 @@ defmodule Aion.Subject do
   This model represents a category of questions.
   """
   use Aion.Web, :model
-
+  alias Aion.{Room, RoomSubject}
   schema "subjects" do
     field :name, :string
-
+    many_to_many :rooms, Room, join_through: RoomSubject
     timestamps()
   end
 

--- a/aion/web/router.ex
+++ b/aion/web/router.ex
@@ -30,7 +30,7 @@ defmodule Aion.Router do
     resources "/subjects", SubjectController, except: [:new, :edit]
     resources "/questions", QuestionController, except: [:new, :edit]
     resources "/answers", AnswerController, except: [:new, :edit]
-    resources "/rooms", Aion.RoomController, except: [:new, :edit]
+    resources "/rooms", RoomController, except: [:new, :edit]
     resources "/room_subjects", RoomSubjectController, except: [:new, :edit]
   end
 end

--- a/aion/web/router.ex
+++ b/aion/web/router.ex
@@ -30,5 +30,7 @@ defmodule Aion.Router do
     resources "/subjects", SubjectController, except: [:new, :edit]
     resources "/questions", QuestionController, except: [:new, :edit]
     resources "/answers", AnswerController, except: [:new, :edit]
+    resources "/rooms", Aion.RoomController, except: [:new, :edit]
+    resources "/room_subjects", RoomSubjectController, except: [:new, :edit]
   end
 end

--- a/aion/web/views/room_subject_view.ex
+++ b/aion/web/views/room_subject_view.ex
@@ -1,0 +1,17 @@
+defmodule Aion.RoomSubjectView do
+  use Aion.Web, :view
+
+  def render("index.json", %{room_subjects: room_subjects}) do
+    %{data: render_many(room_subjects, Aion.RoomSubjectView, "room_subject.json")}
+  end
+
+  def render("show.json", %{room_subject: room_subject}) do
+    %{data: render_one(room_subject, Aion.RoomSubjectView, "room_subject.json")}
+  end
+
+  def render("room_subject.json", %{room_subject: room_subject}) do
+    %{id: room_subject.id,
+      room_id: room_subject.room_id,
+      subject_id: room_subject.subject_id}
+  end
+end

--- a/aion/web/views/room_view.ex
+++ b/aion/web/views/room_view.ex
@@ -12,7 +12,6 @@ defmodule Aion.RoomView do
   def render("room.json", %{room: room}) do
     %{id: room.id,
       name: room.name,
-      description: room.description,
-      owner: room.owner}
+      description: room.description}
   end
 end

--- a/aion/web/views/room_view.ex
+++ b/aion/web/views/room_view.ex
@@ -1,0 +1,18 @@
+defmodule Aion.RoomView do
+  use Aion.Web, :view
+
+  def render("index.json", %{rooms: rooms}) do
+    %{data: render_many(rooms, Aion.RoomView, "room.json")}
+  end
+
+  def render("show.json", %{room: room}) do
+    %{data: render_one(room, Aion.RoomView, "room.json")}
+  end
+
+  def render("room.json", %{room: room}) do
+    %{id: room.id,
+      name: room.name,
+      description: room.description,
+      owner: room.owner}
+  end
+end


### PR DESCRIPTION
**Summary**
This PR adds Room model along with RoomSubject which is a join table between rooms and subjects (we want each subject to be in many rooms and each room to possibly aggregate any subjects)

Below the way the generated Room table looks:
![image](https://user-images.githubusercontent.com/15965147/27985146-1e38f3dc-63e6-11e7-8310-b27121cc4c0b.png)

And RoomSubject:
![image](https://user-images.githubusercontent.com/15965147/28893959-942d0d8e-77d3-11e7-8f0d-5c4776269719.png)

And finally updated Subject:
![image](https://user-images.githubusercontent.com/15965147/27985166-7ab9d3ba-63e6-11e7-9443-9f518cf849c8.png)


**Related issues**
#34 

**Test plan**
`mix ecto.migrate && mix test`
