### PR TITLE
fix(docker): Add mix deps.get on container run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - db
-    command: bash /scripts/run_migrations.sh
+    command: bash /scripts/run_server.sh
     volumes:
       - ./aion/:/aion
       - /aion/deps

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -1,3 +1,4 @@
 sleep 4
+mix deps.get
 mix ecto.migrate
 mix phoenix.server


### PR DESCRIPTION
**Summary**

Add mix deps.get before running mix phoenix.server to make sure the
docker container doesn't crash between branches with different library
imports.

Also, I've changed the run_migrations.sh to run_server.sh as this is what the script eventually does. I found the current name confusing when adding the fix (took me a while to understand where we run `mix phoenix.server`).