### PR TITLE
enhancement(travis): Add elm-make to travisfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ install:
       cd ..;
     fi
   - cd aion
+  - mix local.rebar --force
+  - mix local.hex --force
+  - mix deps.get
 
 before_install:
 - cd aion

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 - postgresql
 
 before_install:
-- make local_deps
+- make local-deps
 - cd aion
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,11 @@ before_script:
 - mix do ecto.create, ecto.migrate
 
 script:
-  - cd web/elm && ../../node_modules/elm/binwrappers/elm-package install --yes && ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm && rm -rf index.html && cd ../../
+  - cd web/elm &&
+    ../../node_modules/elm/binwrappers/elm-package install --yes &&
+    ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm &&
+    rm -rf index.html &&
+    cd ../../
   - mix credo --strict
   - mix test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,13 @@ before_script:
 - mix do ecto.create, ecto.migrate
 
 script:
-  - mix credo --strict
-  - mix test
   - cd web/elm && \
     ../../node_modules/elm/binwrappers/elm-package install --yes && \
     ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm && \
-    rm -rf index.html
+    rm -rf index.html && \
+    cd ../../
+  - mix credo --strict
+  - mix test
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,7 @@ before_script:
 - mix do ecto.create, ecto.migrate
 
 script:
-  - cd web/elm && \
-    ../../node_modules/elm/binwrappers/elm-package install --yes && \
-    ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm && \
-    rm -rf index.html && \
-    cd ../../
+  - cd web/elm && ../../node_modules/elm/binwrappers/elm-package install --yes && ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm && rm -rf index.html && cd ../../
   - mix credo --strict
   - mix test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
   directories:
     - sysconfcpus
     - aion/deps
+    - aion/web/elm/elm-stuff/build-artifacts
 
 install:
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,24 @@ sudo: false
 services:
 - postgresql
 
+cache:
+  directories:
+    - sysconfcpus
+    - aion/deps
+
+install:
+  - cd ..
+  - |
+    if [ ! -d sysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
+  - cd aion
+
 before_install:
 - cd aion
 - npm install
@@ -27,7 +45,7 @@ before_script:
 script:
   - cd web/elm &&
     ../../node_modules/elm/binwrappers/elm-package install --yes &&
-    ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm &&
+    $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm &&
     rm -rf index.html &&
     cd ../../
   - mix credo --strict
@@ -37,7 +55,3 @@ notifications:
   email: false
   slack:
     secure: 0wrGLWdpp9HLujCNNwJnPvmfQmK3phQXbUj/EZ/x/YROEp1TdaDzLnXI4Qo6JyZszmH+zFb3S58iiOUrX2oCJFhdUGz/tN8YSBQBdMDPhi602BfarK4dfOSsnMq60KYzEV+zkM3GQFXIl/UudeZ5AhEpEn4tF6HrjSYqMOAJkjv4REesdY/GLDVSFfNF/KfXhd1afsB5IA5O0VMERr247aCtnr9pbHuE6yqicZCuw0aU41e3zPRm8BVUIP1np5jRaGCJs7Vpx/5Q+SpdTjqdtgB05APvHveupDJrGV2uVH2iXScxHIP5SZOJbaaUxkIvjjrMN4IW3IiFDjxDuN6PAFZfJ3mpTowtDl96t4fgOfTM9a/EVv7OlPeQAVkOvHIdfsZ2PUpGV7+yWN1RssyiaYxcHdJ825on2jb+lj7lhsZmlGDfa/8GhkPQuKJr/msaXaposYDa42460hinn4UPHGrgO4AuGrXF9Cc7/xbGIdAkHogsswYy1X2XDf7aDR5yktgz/sQ1aHnvF9K1SzopDd1TS6YjLpgN0Y4kqWrUqWxHM6Ne1mTYLTREfbs+49+oPaq+n+HilFB0BAjCpwtwvKi+VhPgH5ZCSYL0hqiYpsUNL2Q3oWUHra1YlPIc/2QtIf6E1XtpqADRqnI/Ow8XkTgi4xWq2gKmHn5jEZhW9Ng=
-
-cache:
- directories:
-  - aion/deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ services:
 - postgresql
 
 before_install:
-- mix local.hex --force
-- make local-deps
+- npm install
 - cd aion
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ services:
 - postgresql
 
 before_install:
-- npm install
 - cd aion
+- npm install
 
 before_script:
 - cp config/travis.exs config/test.exs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ services:
 - postgresql
 
 before_install:
+- mix local.hex --force
 - make local-deps
 - cd aion
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ services:
 - postgresql
 
 before_install:
+- make local_deps
 - cd aion
 
 before_script:
@@ -26,7 +27,10 @@ before_script:
 script:
   - mix credo --strict
   - mix test
-  - elm-make web/elm/src/App.elm && rm -rf elm-package.json
+  - cd web/elm && \
+    ../../node_modules/elm/binwrappers/elm-package install --yes && \
+    ../../node_modules/elm/binwrappers/elm-make --yes src/App.elm && \
+    rm -rf index.html
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: elixir
 
 elixir:
-  - 1.4
+  - 1.4.5
 otp_release:
   - 20.0
   - 19.3
@@ -26,6 +26,7 @@ before_script:
 script:
   - mix credo --strict
   - mix test
+  - elm-make web/elm/src/App.elm && rm -rf elm-package.json
 
 notifications:
   email: false

--- a/aion/web/elm/elm-package.json
+++ b/aion/web/elm/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/pmrukot/aion.git",
+    "repository": "https://github.com/forcecraft/aion.git",
     "license": "BSD3",
     "source-directories": [
         "src"


### PR DESCRIPTION
**Summary**
This addition got more complex than initially expected. In order to make the travis build time still around 10 minutes I had to add installation of sysconfcpus which takes care of a proper elm compilation. Without it the build took around 28 minutes.

**Related issues**
closes: #96 

**Test plan**
travis build should fail before rebasing vs  fixed master.
