### PR TITLE
fix(elixir): Remove checking for should_change? in change room state

### DIFF
--- a/aion/test/channels/question_chronicle_test.exs
+++ b/aion/test/channels/question_chronicle_test.exs
@@ -34,11 +34,6 @@ defmodule Aion.QuestionChronicleTest do
     %{@room_id => {_, :break}} = QuestionChronicle.list_entries()
   end
 
-  test "cannot change state before timeout" do
-    {:error, :called_too_early} =
-      QuestionChronicle.change_room_state(@room_id, fn -> @current_time end)
-  end
-
   test "state should switch back to :question from break" do
     question_timeout = QuestionChronicle.question_timeout_micro()
     break_timeout = QuestionChronicle.question_break_timeout_micro()


### PR DESCRIPTION
**Summary**
This PR fixes errors being thrown when users answer correctly before the question timeout.

**Related issues**
n/a

**Test plan**
`make test` + manual
