### PR TITLE
refactor(elixir): Move timeouts to config

### DIFF
--- a/aion/config/config.exs
+++ b/aion/config/config.exs
@@ -6,17 +6,19 @@
 use Mix.Config
 
 # General application configuration
-config :aion,
-  ecto_repos: [Aion.Repo]
+config :aion, ecto_repos: [Aion.Repo]
 
 # Configures the endpoint
 config :aion, Aion.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "qILNWNsZ5dyZijpvocG45VG5ElYCLYSfSOAWVEiz+cloUiX177Dla1kbz3ZGrfbX",
   render_errors: [view: Aion.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: Aion.PubSub,
-           adapter: Phoenix.PubSub.PG2],
+  pubsub: [name: Aion.PubSub, adapter: Phoenix.PubSub.PG2],
   hostname: "localhost"
+
+config :aion, Aion.Timeout,
+  question_timeout: 10,
+  question_break_timeout: 5
 
 # Configures Elixir's Logger
 config :logger, :console,
@@ -28,9 +30,9 @@ config :guardian, Guardian,
   allowed_algos: ["HS512"],
   secret_key: System.get_env("SECRET_KEY") || "test",
   issuer: "Aion",
-  ttl: { 30, :days },
+  ttl: {30, :days},
   serializer: Aion.GuardianSerializer
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/aion/config/config.exs
+++ b/aion/config/config.exs
@@ -18,7 +18,8 @@ config :aion, Aion.Endpoint,
 
 config :aion, Aion.Timeout,
   question_timeout: 10,
-  question_break_timeout: 5
+  question_break_timeout: 5,
+  next_question_delay: 1
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/aion/test/channels/question_chronicle_test.exs
+++ b/aion/test/channels/question_chronicle_test.exs
@@ -12,12 +12,12 @@ defmodule Aion.QuestionChronicleTest do
   end
 
   test "should_change? equals false when the time has not exceeded timeout" do
-    time_called = @current_time + QuestionChronicle.question_timeout_micro() - 1000
+    time_called = @current_time + QuestionChronicle.question_timeout(:microsecond) - 1000
     assert not QuestionChronicle.should_change?(@room_id, fn -> time_called end)
   end
 
   test "should_change? equals true when the time has exceeded the timeout" do
-    time_called = @current_time + QuestionChronicle.question_timeout_micro()
+    time_called = @current_time + QuestionChronicle.question_timeout(:microsecond)
     assert QuestionChronicle.should_change?(@room_id, fn -> time_called end)
   end
 
@@ -28,20 +28,15 @@ defmodule Aion.QuestionChronicleTest do
   test "state should switch from :question to :break when change_room_state is called" do
     %{@room_id => {_, :question}} = QuestionChronicle.list_entries()
 
-    after_timeout = @current_time + QuestionChronicle.question_timeout_micro()
+    after_timeout = @current_time + QuestionChronicle.question_timeout(:microsecond)
     QuestionChronicle.change_room_state(@room_id, fn -> after_timeout end)
 
     %{@room_id => {_, :break}} = QuestionChronicle.list_entries()
   end
 
-  test "cannot change state before timeout" do
-    {:error, :called_too_early} =
-      QuestionChronicle.change_room_state(@room_id, fn -> @current_time end)
-  end
-
   test "state should switch back to :question from break" do
-    question_timeout = QuestionChronicle.question_timeout_micro()
-    break_timeout = QuestionChronicle.question_break_timeout_micro()
+    question_timeout = QuestionChronicle.question_timeout(:microsecond)
+    break_timeout = QuestionChronicle.question_break_timeout(:microsecond)
 
     QuestionChronicle.change_room_state(@room_id, fn -> @current_time + question_timeout end)
 

--- a/aion/web/channels/question_chronicle.ex
+++ b/aion/web/channels/question_chronicle.ex
@@ -7,15 +7,9 @@ defmodule Aion.QuestionChronicle do
   """
   @type t :: %{binary => {integer, atom}}
 
-  @question_timeout 10
-
-  def question_timeout_micro, do: @question_timeout * 1_000_000
-  def question_timeout_milli, do: @question_timeout * 1_000
-
-  @question_break_timeout 5
-
-  def question_break_timeout_micro, do: @question_break_timeout * 1_000_000
-  def question_break_timeout_milli, do: @question_break_timeout * 1_000
+  alias Aion.Timeout
+  defdelegate question_timeout(unit), to: Timeout
+  defdelegate question_break_timeout(unit), to: Timeout
 
   def start_link(name \\ __MODULE__) do
     Agent.start_link(fn -> %{} end, name: name)
@@ -36,8 +30,8 @@ defmodule Aion.QuestionChronicle do
 
     timeout =
       case current_state do
-        :question -> question_timeout_micro()
-        :break -> question_break_timeout_micro()
+        :question -> question_timeout(:microsecond)
+        :break -> question_break_timeout(:microsecond)
       end
 
     time.() >= last_changed + timeout
@@ -47,7 +41,7 @@ defmodule Aion.QuestionChronicle do
     entry = {current_time.(), :question}
     Agent.update(__MODULE__, &Map.put(&1, room_id, entry))
 
-    {:ok, question_timeout_milli()}
+    {:ok, question_timeout(:millisecond)}
   end
 
   def remove_room_state(room_id) do
@@ -80,6 +74,6 @@ defmodule Aion.QuestionChronicle do
   defp get_next_state(:question), do: :break
   defp get_next_state(:break), do: :question
 
-  defp get_timeout_for_state(:question), do: question_timeout_milli()
-  defp get_timeout_for_state(:break), do: question_break_timeout_milli()
+  defp get_timeout_for_state(:question), do: question_timeout(:millisecond)
+  defp get_timeout_for_state(:break), do: question_break_timeout(:millisecond)
 end

--- a/aion/web/channels/room_channel.ex
+++ b/aion/web/channels/room_channel.ex
@@ -24,7 +24,7 @@ defmodule Aion.RoomChannel do
 
   # Upon entering question_break state, the next question will be sent after
   # the @next_question_delay timeout
-  @next_question_delay 1000
+  defdelegate next_question_delay(unit), to: Aion.Timeout
 
   @spec join(String.t(), %{}, UserSocket.t()) :: {:ok, UserSocket.t()}
   def join("room:" <> room_id, _params, socket) do
@@ -125,7 +125,7 @@ defmodule Aion.RoomChannel do
   defp enter_question_break_state(socket) do
     send_question_break(socket)
     change_question(socket)
-    :timer.send_after(@next_question_delay, :next_question_timeout)
+    :timer.send_after(next_question_delay(:millisecond), :next_question_timeout)
 
     send_scores(socket)
     new_state_with_timer(socket)

--- a/aion/web/channels/timeout.ex
+++ b/aion/web/channels/timeout.ex
@@ -20,7 +20,7 @@ defmodule Aion.Timeout do
 
   defp get_and_convert(key, unit) do
     key
-    |> get_env
+    |> get_env()
     |> from_seconds(unit)
   end
 

--- a/aion/web/channels/timeout.ex
+++ b/aion/web/channels/timeout.ex
@@ -25,12 +25,12 @@ defmodule Aion.Timeout do
   end
 
   @doc """
-  Returns the timeout after which the question should be changed
+  Returns the timeout after which the question should be changed.
   """
   def question_timeout(unit \\ :second), do: get_and_convert(:question_timeout, unit)
 
   @doc """
-  Returns the timeout after which the question break should end
+  Returns the timeout after which the question break should end.
   """
   def question_break_timeout(unit \\ :second), do: get_and_convert(:question_break_timeout, unit)
 

--- a/aion/web/channels/timeout.ex
+++ b/aion/web/channels/timeout.ex
@@ -4,28 +4,39 @@ defmodule Aion.Timeout do
     and providing a convenient API for other modules
     (making it possible to ask for timeouts in specific units).
   """
-  @micro 1_000_000
-  @milli 1_000
+  defp from_seconds(value, unit) do
+    case unit do
+      :second -> value
+      :millisecond -> value * 1_000
+      :microsecond -> value * 1_000_000
+    end
+  end
 
-  def get_env(key) do
+  defp get_env(key) do
     :aion
     |> Application.get_env(__MODULE__)
     |> Keyword.get(key)
   end
 
+  defp get_and_convert(key, unit) do
+    key
+    |> get_env
+    |> from_seconds(unit)
+  end
+
   @doc """
   Returns the timeout after which the question should be changed
   """
-  def question_timeout(_unit \\ :second)
-  def question_timeout(:second), do: get_env(:question_timeout)
-  def question_timeout(:millisecond), do: question_timeout() * @milli
-  def question_timeout(:microsecond), do: question_timeout() * @micro
+  def question_timeout(unit \\ :second), do: get_and_convert(:question_timeout, unit)
 
   @doc """
   Returns the timeout after which the question break should end
   """
-  def question_break_timeout(_unit \\ :second)
-  def question_break_timeout(:second), do: get_env(:question_break_timeout)
-  def question_break_timeout(:millisecond), do: question_break_timeout() * @milli
-  def question_break_timeout(:microsecond), do: question_break_timeout() * @micro
+  def question_break_timeout(unit \\ :second), do: get_and_convert(:question_break_timeout, unit)
+
+  @doc """
+  The next question shall be sent next_question_delay units of time after introducing
+  question_break state.
+  """
+  def next_question_delay(unit \\ :second), do: get_and_convert(:next_question_delay, unit)
 end

--- a/aion/web/channels/timeout.ex
+++ b/aion/web/channels/timeout.ex
@@ -1,0 +1,31 @@
+defmodule Aion.Timeout do
+  @moduledoc """
+    This module takes care of importing timeouts from configs
+    and providing a convenient API for other modules
+    (making it possible to ask for timeouts in specific units).
+  """
+  @micro 1_000_000
+  @milli 1_000
+
+  def get_env(key) do
+    :aion
+    |> Application.get_env(__MODULE__)
+    |> Keyword.get(key)
+  end
+
+  @doc """
+  Returns the timeout after which the question should be changed
+  """
+  def question_timeout(_unit \\ :second)
+  def question_timeout(:second), do: get_env(:question_timeout)
+  def question_timeout(:millisecond), do: question_timeout() * @milli
+  def question_timeout(:microsecond), do: question_timeout() * @micro
+
+  @doc """
+  Returns the timeout after which the question break should end
+  """
+  def question_break_timeout(_unit \\ :second)
+  def question_break_timeout(:second), do: get_env(:question_break_timeout)
+  def question_break_timeout(:millisecond), do: question_break_timeout() * @milli
+  def question_break_timeout(:microsecond), do: question_break_timeout() * @micro
+end


### PR DESCRIPTION
**Summary**
This PR moves out all the time constants to config and provides an `Aion.Timeout` module delivering API for getting the timeouts in a variety of units.

**Related issues**
closes: #169 

**Test plan**
`make test`
