### PR TITLE
fix: Change rooms with all categories names to Varia

### DIFF
--- a/fixtures/src/populate_rooms.py
+++ b/fixtures/src/populate_rooms.py
@@ -9,7 +9,7 @@ def populate_one_category_rooms(conn, questions_threshold):
     for category_id, category_name in category_dict.items():
         questions = get_questions_from_category(category_id, conn)
         if questions and len(questions) > questions_threshold:
-            room_id = get_or_insert_room(category_name, category_name, conn)
+            room_id = get_or_insert_room(category_name.title(), category_name, conn)
             get_or_insert_rooms_to_categories(room_id, category_id, conn)
 
 

--- a/fixtures/src/populate_rooms.py
+++ b/fixtures/src/populate_rooms.py
@@ -18,6 +18,6 @@ def populate_all_categories_rooms(conn):
     rooms_number = 5
 
     for i in range(rooms_number):
-        room_id = get_or_insert_room("wiedza ogólna {}".format(i), "room with all categories", conn)
+        room_id = get_or_insert_room("Varia {}".format(i), "room with all categories", conn)
         for category_id in categories_id_list:
             get_or_insert_rooms_to_categories(room_id, category_id, conn)


### PR DESCRIPTION
**Summary**
As pointed out by client, rooms that aggregate all categories should be called `Varia`.
