### PR TITLE
fix(elm): Remove race condition in progress bar

### DIFF
--- a/aion/web/elm/src/Room/Constants.elm
+++ b/aion/web/elm/src/Room/Constants.elm
@@ -1,7 +1,6 @@
 module Room.Constants exposing (..)
 
 import Navigation exposing (Location)
-import Time exposing (Time, millisecond)
 import Urls exposing (host)
 
 

--- a/aion/web/elm/src/Room/Utils.elm
+++ b/aion/web/elm/src/Room/Utils.elm
@@ -47,7 +47,7 @@ progressBarTick progressBar time =
             nextProgress > 100
 
         ( running, progress ) =
-            if finishedLoading == True then
+            if finishedLoading then
                 ( Stopped, nextProgress )
             else
                 ( Running, nextProgress )

--- a/aion/web/elm/src/Update.elm
+++ b/aion/web/elm/src/Update.elm
@@ -682,7 +682,12 @@ update msg model =
         OnTime time ->
             let
                 progressBar =
-                    progressBarTick model.progressBar time
+                    case model.progressBar.running of
+                        Running ->
+                            progressBarTick model.progressBar time
+
+                        _ ->
+                            model.progressBar
             in
                 (progressBar |> asProgressBarIn model)
                     ! case progressBar.running of


### PR DESCRIPTION
**Summary**
This PR deals with race condition we've got due to current-time task. I'm not 100% sure, but I bet the problem with progress bar not stopping occurs when the `QuestionBreak` message arrives in between the call to Time task and its response. 

The changes in this PR double check that the progressBar is still `Running` when the time is received. 

**Related issues**
closes: #190 

**Test plan**
manual
